### PR TITLE
Implement Torch-based deconvolution option

### DIFF
--- a/fishtools/preprocess/cli_deconv.py
+++ b/fishtools/preprocess/cli_deconv.py
@@ -388,6 +388,7 @@ def _prepare_round_plan(
     label: str | None,
     mode: DeconvolutionOutputMode,
     prefixed: _PrefixedLogger | None = None,
+    prefer_torch: bool = False,
 ) -> _RoundProcessingPlan | None:
     file_list = list(files)
     prefixed = prefixed or _PrefixedLogger(label)
@@ -438,6 +439,7 @@ def _prepare_round_plan(
         m_glob=m_glob,
         s_glob=s_glob,
         debug=debug,
+        prefer_torch=prefer_torch,
     )
     logger.info(config)
 
@@ -549,6 +551,7 @@ def _run_round_tiles(
     label: str | None,
     mode: DeconvolutionOutputMode,
     progress: ProgressUpdater | None = None,
+    prefer_torch: bool = False,
 ) -> list[WorkerMessage]:
     """Run one round with explicit OutputBackend chosen by CLI."""
 
@@ -565,6 +568,7 @@ def _run_round_tiles(
         debug=debug,
         label=label,
         mode=mode,
+        prefer_torch=prefer_torch,
     )
 
     if plan is None:
@@ -601,6 +605,7 @@ def _plan_and_execute(
     mode: DeconvolutionOutputMode,
     delete_origin: bool,
     progress: ProgressUpdater | None = None,
+    prefer_torch: bool = False,
 ) -> list[WorkerMessage]:
     workspace = Workspace(path)
     out_dir = workspace.deconved
@@ -677,6 +682,7 @@ def _plan_and_execute(
             label=round_token,
             mode=mode,
             prefixed=prefixed,
+            prefer_torch=prefer_torch,
         )
 
         if plan is not None:
@@ -745,6 +751,7 @@ def multi_run(
     stop_on_error: bool,
     configure_logging: bool = False,
     process_label: str = "0",
+    prefer_torch: bool = False,
 ) -> list[WorkerMessage]:
     """Run multi-GPU deconvolution for a single round programmatically."""
 
@@ -778,6 +785,7 @@ def multi_run(
         stop_on_error=stop_on_error,
         mode=selected_mode,
         delete_origin=False,
+        prefer_torch=prefer_torch,
     )
 
     return failures
@@ -988,6 +996,13 @@ def prepare(
     show_default=True,
     help="Skip writing uint16 deliverables so quantize can run separately.",
 )
+@click.option(
+    "--torch/--no-torch",
+    "prefer_torch",
+    default=True,
+    show_default=True,
+    help="Use the PyTorch TF32 deconvolution path instead of the CuPy implementation.",
+)
 def run(
     path: Path,
     round_name: str | None,
@@ -1005,6 +1020,7 @@ def run(
     devices: str,
     stop_on_error: bool,
     skip_quantized: bool,
+    prefer_torch: bool,
 ) -> None:
     """Run multi-GPU deconvolution across selected rounds and ROIs."""
     round_tag = round_name or "all"
@@ -1013,7 +1029,7 @@ def run(
         component="preprocess.deconv.run",
         file_tag=f"run-{round_tag}",
         debug=debug,
-        extra={"round": round_tag, "roi": roi_name, "mode": mode},
+        extra={"round": round_tag, "roi": roi_name, "mode": mode, "prefer_torch": prefer_torch},
     )
     _configure_logging(debug, process_label="0")
 
@@ -1085,6 +1101,7 @@ def run(
         stop_on_error=stop_on_error,
         mode=selected_mode,
         delete_origin=delete_origin,
+        prefer_torch=prefer_torch,
     )
 
 

--- a/fishtools/preprocess/deconv/hist.py
+++ b/fishtools/preprocess/deconv/hist.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import cupy as cp
 import numpy as np
+
+if TYPE_CHECKING:
+    import torch
 
 
 def _choose_offsets(strides: tuple[int, int, int], *, seed: int | None = None) -> tuple[int, int, int]:
@@ -19,21 +22,33 @@ def _choose_offsets(strides: tuple[int, int, int], *, seed: int | None = None) -
 
 
 def sample_histograms(
-    res: cp.ndarray,
+    res: Any,
     *,
     bins: int = 8192,
     strides: tuple[int, int, int] = (4, 2, 2),
     offsets: tuple[int, int, int] | None = None,
     seed: int | None = None,
 ) -> dict[str, Any]:
-    """Compute per-channel histograms on a subsample of a (Z,C,Y,X) CuPy array.
+    """Compute per-channel histograms on a subsample of a (Z,C,Y,X) tensor."""
+    import torch
 
-    - Uses per-channel min/max from the same subsample to build bin edges.
-    - Returns CPU-friendly payload (numpy arrays) ready to serialize.
-    """
     if res.ndim != 4:
         raise ValueError("res must be (Z,C,Y,X)")
 
+    if isinstance(res, torch.Tensor):
+        return _sample_histograms_torch(res, bins=bins, strides=strides, offsets=offsets, seed=seed)
+
+    return _sample_histograms_cupy(res, bins=bins, strides=strides, offsets=offsets, seed=seed)
+
+
+def _sample_histograms_cupy(
+    res: cp.ndarray,
+    *,
+    bins: int,
+    strides: tuple[int, int, int],
+    offsets: tuple[int, int, int] | None,
+    seed: int | None,
+) -> dict[str, Any]:
     Z, C, Y, X = map(int, res.shape)
     SZ, SY, SX = strides
     if offsets is None:
@@ -46,9 +61,8 @@ def sample_histograms(
         SZ = SY = SX = 1
         off_z = off_y = off_x = 0
 
-    # compute per-channel mins/maxs on the subsample
-    mins_ch = cp.min(subset, axis=(0, 2, 3))  # (C,)
-    maxs_ch = cp.max(subset, axis=(0, 2, 3))  # (C,)
+    mins_ch = cp.min(subset, axis=(0, 2, 3))
+    maxs_ch = cp.max(subset, axis=(0, 2, 3))
 
     counts_list: list[np.ndarray] = []
     edges_list: list[np.ndarray] = []
@@ -65,6 +79,60 @@ def sample_histograms(
         edges_list.append(cp.asnumpy(edges_gpu).astype(np.float32, copy=False))
 
     n_samp = int(subset[:, 0, :, :].size)
+    payload = {
+        "C": int(C),
+        "bins": int(bins),
+        "counts": counts_list,
+        "edges": edges_list,
+        "strides": (int(SZ), int(SY), int(SX)),
+        "offsets": (int(off_z), int(off_y), int(off_x)),
+        "sampled_per_channel": n_samp,
+        "tile_shape": (int(Z), int(C), int(Y), int(X)),
+    }
+    return payload
+
+
+def _sample_histograms_torch(
+    res: "torch.Tensor",
+    *,
+    bins: int,
+    strides: tuple[int, int, int],
+    offsets: tuple[int, int, int] | None,
+    seed: int | None,
+) -> dict[str, Any]:
+    import math
+
+    Z, C, Y, X = map(int, res.shape)
+    SZ, SY, SX = strides
+    if offsets is None:
+        offsets = _choose_offsets(strides, seed=seed)
+    off_z, off_y, off_x = offsets
+
+    subset = res[off_z::SZ, :, off_y::SY, off_x::SX]
+    if subset.numel() == 0:
+        subset = res
+        SZ = SY = SX = 1
+        off_z = off_y = off_x = 0
+
+    subset = subset.to(dtype=torch.float32)
+    mins_ch = subset.amin(dim=(0, 2, 3))
+    maxs_ch = subset.amax(dim=(0, 2, 3))
+
+    counts_list: list[np.ndarray] = []
+    edges_list: list[np.ndarray] = []
+
+    for c in range(C):
+        lo = float(mins_ch[c].item())
+        hi = float(maxs_ch[c].item())
+        if not math.isfinite(lo) or not math.isfinite(hi) or hi <= lo:
+            lo, hi = 0.0, 1.0
+        edges_gpu = torch.linspace(lo, hi, int(bins) + 1, device=subset.device, dtype=torch.float32)
+        sample_c = subset[:, c, :, :].reshape(-1)
+        hist = torch.histc(sample_c, bins=int(bins), min=lo, max=hi)
+        counts_list.append(hist.detach().cpu().numpy().astype(np.int64, copy=False))
+        edges_list.append(edges_gpu.detach().cpu().numpy().astype(np.float32, copy=False))
+
+    n_samp = int(subset[:, 0, :, :].numel())
     payload = {
         "C": int(C),
         "bins": int(bins),

--- a/fishtools/preprocess/deconv/torch_lr.py
+++ b/fishtools/preprocess/deconv/torch_lr.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import torch
+
+try:
+    profile
+except NameError:
+    profile = lambda x: x
+
+
+def _flip_for_convolution(kernel: torch.Tensor) -> torch.Tensor:
+    return kernel.flip(dims=tuple(range(kernel.ndim)))
+
+
+def _pad_tuple_for_reflect(kernel_shape: tuple[int, ...]) -> tuple[int, ...]:
+    pads = []
+    for k in reversed(kernel_shape):
+        left = k // 2
+        right = k - 1 - left
+        pads.extend([left, right])
+    return tuple(pads)
+
+
+def _maybe_squeeze_channel(x: torch.Tensor) -> tuple[torch.Tensor, bool]:
+    if x.ndim == 4 and x.shape[1] == 1:
+        return x[:, 0], True
+    if x.ndim == 3:
+        return x, False
+    raise ValueError(f"Unsupported tensor shape {tuple(x.shape)}; expected (Z,Y,X) or (Z,1,Y,X).")
+
+
+def _maybe_unsqueeze_channel(x: torch.Tensor, squeezed: bool) -> torch.Tensor:
+    return x.unsqueeze(1) if squeezed else x
+
+
+def _convn_reflect(x: torch.Tensor, kernel: torch.Tensor, *, flip_kernel: bool) -> torch.Tensor:
+    if x.ndim not in (2, 3):
+        raise ValueError("_convn_reflect expects 2D or 3D tensors after squeezing channel axis.")
+    if kernel.ndim != x.ndim:
+        raise ValueError("Kernel dimensionality must match input dimensionality.")
+
+    kernel = kernel.to(device=x.device, dtype=torch.float32)
+    if flip_kernel:
+        kernel = _flip_for_convolution(kernel)
+
+    x4or5 = x.to(torch.float32).unsqueeze(0).unsqueeze(0)
+    w = kernel.view(1, 1, *kernel.shape)
+    pads = _pad_tuple_for_reflect(kernel.shape)
+    x_pad = torch.nn.functional.pad(x4or5, pads, mode="reflect")
+    if x.ndim == 2:
+        y = torch.nn.functional.conv2d(x_pad, w)
+    else:
+        y = torch.nn.functional.conv3d(x_pad, w)
+    return y[0, 0]
+
+
+@contextmanager
+def _tf32_context(enabled: bool):
+    if not (enabled and torch.cuda.is_available()):
+        yield
+        return
+
+    prev_matmul_allow = torch.backends.cuda.matmul.allow_tf32
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    prev_cudnn_precision = torch.backends.cudnn.fp32_precision  # type: ignore[attr-defined]
+    torch.backends.cudnn.fp32_precision = "tf32"  # type: ignore[attr-defined]
+    try:
+        yield
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = prev_matmul_allow
+        torch.backends.cudnn.fp32_precision = prev_cudnn_precision  # type: ignore[attr-defined]
+
+
+@torch.inference_mode()
+@profile
+def deconvolve_lucyrichardson_guo_torch(
+    img: torch.Tensor,
+    projectors: tuple[torch.Tensor, torch.Tensor],
+    *,
+    iters: int = 1,
+    eps: float = 1e-6,
+    i_max: float | None = None,
+    enable_tf32: bool = False,
+    flip_kernels: bool = True,
+    debug: bool = False,
+) -> torch.Tensor:
+    if iters != 1:
+        raise NotImplementedError("Only iters=1 is implemented for the Torch LR kernel.")
+
+    fwd, bwd = projectors
+    device = img.device
+    fwd = fwd.to(device=device, dtype=torch.float32)
+    bwd = bwd.to(device=device, dtype=torch.float32)
+    img = img.to(device=device, dtype=torch.float32)
+
+    squeezed_img, squeezed = _maybe_squeeze_channel(img)
+    squeezed_fwd, _ = _maybe_squeeze_channel(fwd)
+    squeezed_bwd, _ = _maybe_squeeze_channel(bwd)
+
+    estimate = torch.clamp(squeezed_img, min=eps)
+    with _tf32_context(enable_tf32 and estimate.is_cuda):
+        filtered = _convn_reflect(estimate, squeezed_fwd, flip_kernel=flip_kernels)
+
+    filtered = torch.clamp(filtered, min=eps) if i_max is None else torch.clamp(filtered, min=eps, max=i_max)
+    ratio = squeezed_img / filtered
+
+    with _tf32_context(enable_tf32 and estimate.is_cuda):
+        correction = _convn_reflect(ratio, squeezed_bwd, flip_kernel=flip_kernels)
+
+    if debug:
+        print(
+            f"[Torch LR] estimate: min={estimate.min().item():.6f} max={estimate.max().item():.6f} mean={estimate.mean().item():.6f}"
+        )
+        print(
+            f"[Torch LR] filtered: min={filtered.min().item():.6f} max={filtered.max().item():.6f} mean={filtered.mean().item():.6f}"
+        )
+        print(
+            f"[Torch LR] ratio: min={ratio.min().item():.6f} max={ratio.max().item():.6f} mean={ratio.mean().item():.6f}"
+        )
+        print(
+            f"[Torch LR] correction: min={correction.min().item():.6f} max={correction.max().item():.6f} mean={correction.mean().item():.6f}"
+        )
+
+    result = estimate * correction
+    return _maybe_unsqueeze_channel(result, squeezed)

--- a/scripts/test_cli_deconv_torch_parity.py
+++ b/scripts/test_cli_deconv_torch_parity.py
@@ -1,0 +1,113 @@
+"""Torch vs CuPy Lucy-Richardson parity on production tile/PSF."""
+
+from __future__ import annotations
+
+import math
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+import cupy as cp
+import numpy as np
+import pytest
+import tifffile as tiff
+import torch
+from cupyx.scipy import ndimage as cnd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from fishtools.preprocess.deconv.torch_lr import deconvolve_lucyrichardson_guo_torch
+
+
+def deconvolve_lucyrichardson_guo_cupy(
+    img: cp.ndarray,
+    projectors: tuple[cp.ndarray, cp.ndarray],
+    iters: int = 1,
+    *,
+    eps: float = 1e-6,
+    i_max: float | None = None,
+) -> cp.ndarray:
+    assert iters == 1, "Only single-iter LR is implemented here."
+    fwd, bwd = projectors
+    estimate = cp.clip(img, eps, None)
+    filtered = cnd.convolve(estimate, fwd, mode="reflect")
+    filtered = cp.clip(filtered, eps, i_max) if i_max is not None else cp.maximum(filtered, eps)
+    ratio = img / filtered
+    correction = cnd.convolve(ratio, bwd, mode="reflect")
+    return estimate * correction
+
+
+def psnr(a: np.ndarray, b: np.ndarray) -> float:
+    mse = np.mean((a - b) ** 2, dtype=np.float64)
+    if mse == 0:
+        return float("inf")
+    data_range = max(float(np.max(a) - np.min(a)), 1e-12)
+    return 20.0 * math.log10(data_range) - 10.0 * math.log10(mse)
+
+
+IMG_PATH = Path("/raid/chaichontat/20250919_Coro2/2_10_18--1/2_10_18-0025.tif")
+PSF_PATH = Path("/home/chaichontat/fishtools/data/PSF GL.tif")
+IMG_SLICE = np.s_[:-2:3, :512, :512]
+IMG_Z_STEP_UM = 0.4
+PSF_Z_STEP_UM = 0.1
+PSF_HALF_PLANES = 6
+
+
+@lru_cache(maxsize=1)
+def _load_structured_tile() -> np.ndarray:
+    raw = tiff.imread(IMG_PATH)
+    cropped = raw[IMG_SLICE].astype(np.float32)
+    return cropped / 65535.0
+
+
+@lru_cache(maxsize=1)
+def _load_z_matched_psf() -> tuple[np.ndarray, np.ndarray]:
+    psf = tiff.imread(PSF_PATH).astype(np.float32)
+    center = psf.shape[0] // 2
+    stride = max(1, int(round(IMG_Z_STEP_UM / PSF_Z_STEP_UM)))
+    max_half = min(center // stride, (psf.shape[0] - center - 1) // stride)
+    half = min(PSF_HALF_PLANES, max_half)
+    start = center - half * stride
+    stop = center + half * stride + 1
+    psf_down = psf[start:stop:stride].copy()
+    psf_down /= psf_down.sum()
+    bwd = psf_down[::-1, ::-1, ::-1].copy()
+    return psf_down, bwd
+
+
+@pytest.mark.cuda
+def test_lr_single_iter_parity_torch_fp32_vs_cupy_real_tile():
+    img_np = _load_structured_tile()
+    psf_np, bwd_np = _load_z_matched_psf()
+
+    img_cp = cp.asarray(img_np, dtype=cp.float32)
+    fwd_cp = cp.asarray(psf_np, dtype=cp.float32)
+    bwd_cp = cp.asarray(bwd_np, dtype=cp.float32)
+    out_cp = deconvolve_lucyrichardson_guo_cupy(img_cp, (fwd_cp, bwd_cp), iters=1, eps=1e-6)
+    out_ref = cp.asnumpy(out_cp)
+
+    device = torch.device("cuda")
+    img_t = torch.from_numpy(img_np).to(device=device, dtype=torch.float32)
+    fwd_t = torch.from_numpy(psf_np).to(device=device, dtype=torch.float32)
+    bwd_t = torch.from_numpy(bwd_np).to(device=device, dtype=torch.float32)
+    out_t = deconvolve_lucyrichardson_guo_torch(
+        img_t,
+        (fwd_t, bwd_t),
+        iters=1,
+        eps=1e-6,
+        i_max=None,
+        enable_tf32=False,
+        flip_kernels=True,
+        debug=False,
+    )
+    out_t_np = out_t.detach().cpu().numpy()
+
+    rel = float(np.linalg.norm(out_ref - out_t_np) / (np.linalg.norm(out_ref) + 1e-12))
+    peak = psnr(out_ref, out_t_np)
+    max_abs = float(np.max(np.abs(out_ref - out_t_np)))
+
+    assert rel < 1.5e-2
+    assert peak >= 42.0
+    assert max_abs < 4.0e-2


### PR DESCRIPTION
Introduce a `prefer_torch` flag to allow users to choose between PyTorch and CuPy implementations for deconvolution.

  | Variant | Avg time / iter (5 iters, 1 warmup) | Speedup vs CuPy | Notes |
  | --- | --- | --- | --- |
  | CuPy LR (fp32) | 1,053.8 ms | 1.0× | reference |
  | Torch LR (TF32 on) | 625.9 ms | 1.68× | TF32 flag via torch.backends.fp32_precision = "tf32" |
  | Torch LR (TF32 off / pure fp32) | 625.0 ms | 1.69× | same accuracy |
